### PR TITLE
Add variant retriever factory

### DIFF
--- a/src/Factory/VariantRetrieverFactory.php
+++ b/src/Factory/VariantRetrieverFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Travaux\VariantRetriever\Factory;
+
+use Travaux\VariantRetriever\Retriever\VariantRetriever;
+use Travaux\VariantRetriever\Retriever\VariantRetrieverInterface;
+use Travaux\VariantRetriever\ValueObject\Experiment;
+use Travaux\VariantRetriever\ValueObject\Variant;
+
+final class VariantRetrieverFactory
+{
+    public function createVariantRetriever(array ...$experiments): VariantRetrieverInterface
+    {
+        $variantRetriever = new VariantRetriever();
+        foreach (call_user_func_array('array_merge', $experiments) as $experimentName => $variants) {
+                $experimentVariants = [];
+                foreach (call_user_func_array('array_merge', $variants) as $variantName => $variantRollout) {
+                    $experimentVariants[] = new Variant($variantName, $variantRollout);
+                }
+                $variantRetriever->addExperiment(new Experiment($experimentName, ...$experimentVariants));
+        }
+        return $variantRetriever;
+    }
+}

--- a/tests/Functional/FactoryTestCase.php
+++ b/tests/Functional/FactoryTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+use Travaux\VariantRetriever\Exception\LogicalException;
+use Travaux\VariantRetriever\Factory\VariantRetrieverFactory;
+use Travaux\VariantRetriever\Retriever\VariantRetriever;
+use Travaux\VariantRetriever\ValueObject\Experiment;
+use Travaux\VariantRetriever\ValueObject\Variant;
+
+
+test('factory return a correct variant retriever', function () {
+
+    $variantRetrieverFactory = new VariantRetrieverFactory();
+
+    $configuration = [
+        0 => [
+            DEFAULT_EXPERIMENT_NAME =>
+            [
+                'control' => 50,
+                'variant' => 50
+            ]
+        ]
+    ];
+
+    $this->assertEquals($variantRetrieverFactory->createVariantRetriever($configuration), generateVariantRetriever());
+});


### PR DESCRIPTION
Create a VariantRetrieverFactory to have simpler configuration with YAML.


```
services:
    App\Utils\VariantRetriever:
        factory:   ['@Travaux\VariantRetriever\Factory\VariantRetrieverFactory', 'createVariantRetriever']
        public: true
        arguments:
            - show-email:
                - control-email: 50
                - participant-email: 50
            - display-cta:
                - control-cta: 75
                - participant-cta: 25
```