### PR TITLE
Add variant retriever factory

### DIFF
--- a/src/Factory/VariantRetrieverFactory.php
+++ b/src/Factory/VariantRetrieverFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Travaux\VariantRetriever\Factory;
+
+use Travaux\VariantRetriever\Retriever\VariantRetriever;
+use Travaux\VariantRetriever\Retriever\VariantRetrieverInterface;
+use Travaux\VariantRetriever\ValueObject\Experiment;
+use Travaux\VariantRetriever\ValueObject\Variant;
+
+final class VariantRetrieverFactory
+{
+    public function createVariantRetriever(array ...$experiments): VariantRetrieverInterface
+    {
+        $variantRetriever = new VariantRetriever();
+        foreach (call_user_func_array('array_merge', $experiments) as $experimentName => $variants) {
+                $experimentVariants = [];
+                foreach (call_user_func_array('array_merge', $variants) as $variantName => $variantRollout) {
+                    $experimentVariants[] = new Variant($variantName, $variantRollout);
+                }
+                $variantRetriever->addExperiment(new Experiment($experimentName, ...$experimentVariants));
+        }
+        return $variantRetriever;
+    }
+}

--- a/tests/Functional/FactoryTestCase.php
+++ b/tests/Functional/FactoryTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+use Travaux\VariantRetriever\Exception\LogicalException;
+use Travaux\VariantRetriever\Factory\VariantRetrieverFactory;
+use Travaux\VariantRetriever\Retriever\VariantRetriever;
+use Travaux\VariantRetriever\ValueObject\Experiment;
+use Travaux\VariantRetriever\ValueObject\Variant;
+
+test('factory return a correct variant retriever', function () {
+    $variantRetrieverFactory = new VariantRetrieverFactory();
+
+    $configuration = [
+        DEFAULT_EXPERIMENT_NAME => [
+            0 =>
+            [
+                'control' => 50,
+                'variant' => 50
+            ]
+        ]
+    ];
+
+    $this->assertEquals($variantRetrieverFactory->createVariantRetriever($configuration), generateVariantRetriever());
+});

--- a/tests/Functional/RolloutPercentageTestCase.php
+++ b/tests/Functional/RolloutPercentageTestCase.php
@@ -23,7 +23,21 @@ test('integer following list should have a correct percentage rollout', function
     $this->assertGreaterThanOrEqual(240, $rollout['variant']); // 48
 });
 
+test('small list should have a correct percentage rollout', function () {
+    $variantRetriever = generateVariantRetriever();
 
+    $results = [];
+    foreach (range(1, 100) as $value) {
+        $results[] = $variantRetriever->getVariantForExperiment(new Experiment('my-ab-test'), (string)$value);
+    }
+
+    $this->assertCount(100, $results);
+
+    $rollout = array_count_values(readRollout($results));
+
+    $this->assertGreaterThanOrEqual(40, $rollout['control']); // 40
+    $this->assertGreaterThanOrEqual(40, $rollout['variant']); // 40
+});
 
 test('Random numbers should have a correct percentage rollout', function () {
     $variantRetriever = generateVariantRetriever();


### PR DESCRIPTION
Create a VariantRetrieverFactory to have simpler configuration with a php array:
```php
    $configuration = [
        'my-ab-test' => [
            0 =>
            [
                'control' => 50,
                'variant' => 50
            ]
        ]
    ];
    $variantRetrieverFactory = new VariantRetrieverFactory();
    $variantRetrieverFactory->createVariantRetriever($configuration)
```
Or even use it with Symfony DIC and YAML configuration:

```yaml
services:
    App\Utils\VariantRetriever:
        factory:   ['@Travaux\VariantRetriever\Factory\VariantRetrieverFactory', 'createVariantRetriever']
        public: true
        arguments:
            - show-email:
                - control-email: 50
                - participant-email: 50
            - display-cta:
                - control-cta: 75
                - participant-cta: 25
```