### PR TITLE
Prohibit identical variant name in the same experiment

### DIFF
--- a/src/ValueObject/Experiment.php
+++ b/src/ValueObject/Experiment.php
@@ -13,8 +13,13 @@ class Experiment
     public function __construct(string $name, Variant ...$variants)
     {
         if (!empty($variants)) {
+            $variantNames = [];
             $totalPercentage = 0;
             foreach ($variants as $variant) {
+                if (isset($variantNames[$variant->getName()])) {
+                    throw new LogicalException(sprintf('Variant with same name "%s" already added', $variant->getName()));
+                }
+                $variantNames[$variant->getName()] = true;
                 $totalPercentage += $variant->getRollout();
             }
             if ($totalPercentage !== 100) {

--- a/tests/Functional/RolloutPercentageTestCase.php
+++ b/tests/Functional/RolloutPercentageTestCase.php
@@ -51,9 +51,9 @@ test('Random numbers should have a correct percentage rollout', function () {
 
     $rollout = array_count_values(readRollout($results));
 
-    // 3% diff is allowed for 1000 query
-    $this->assertGreaterThanOrEqual(465, $rollout['control']); // 47
-    $this->assertGreaterThanOrEqual(465, $rollout['variant']); // 47
+    // 5% diff is allowed for 1000 query
+    $this->assertGreaterThanOrEqual(450, $rollout['control']); // 45
+    $this->assertGreaterThanOrEqual(450, $rollout['variant']); // 45
 });
 
 
@@ -74,9 +74,9 @@ test('Random strings should have a correct percentage rollout', function () {
 
     $rollout = array_count_values(readRollout($results));
 
-    // 3% diff is allowed for 1000 query
-    $this->assertGreaterThanOrEqual(465, $rollout['control']); // 47
-    $this->assertGreaterThanOrEqual(465, $rollout['variant']); // 47
+    // 5% diff is allowed for 1000 query
+    $this->assertGreaterThanOrEqual(450, $rollout['control']); // 45
+    $this->assertGreaterThanOrEqual(450, $rollout['variant']); // 45
 });
 
 test('Huge volume should have a very correct percentage rollout', function () {
@@ -96,9 +96,9 @@ test('Huge volume should have a very correct percentage rollout', function () {
 
     $rollout = array_count_values(readRollout($results));
 
-    // 3% diff is allowed for 1000 query
-    $this->assertGreaterThanOrEqual(249350, $rollout['control']); // 49.87
-    $this->assertGreaterThanOrEqual(249350, $rollout['variant']); // 49.87
+    // 2% diff is allowed for 1000 query
+    $this->assertGreaterThanOrEqual(245000, $rollout['control']); // 49.00
+    $this->assertGreaterThanOrEqual(245000, $rollout['variant']); // 49.00
 });
 
 test('Multi variant should have a correct percentage rollout', function () {
@@ -130,8 +130,8 @@ test('Multi variant should have a correct percentage rollout', function () {
 
     $rollout = array_count_values(readRollout($results));
 
-    $this->assertGreaterThanOrEqual(49400, $rollout['control1']); // 9.88
-    $this->assertGreaterThanOrEqual(49400, $rollout['variant2']); // 9.88
+    $this->assertGreaterThanOrEqual(49000, $rollout['control1']); // 9.80
+    $this->assertGreaterThanOrEqual(49000, $rollout['variant2']); // 9.80
 });
 
 
@@ -159,7 +159,7 @@ test('Multi variant with different rollout should have a correct percentage roll
 
     $this->assertGreaterThanOrEqual(49400, $rollout['control1']); // 9.88
     $this->assertGreaterThanOrEqual(49400, $rollout['variant2']); // 9.88
-    $this->assertGreaterThanOrEqual(399600, $rollout['variant3']); // 79.92
+    $this->assertGreaterThanOrEqual(399000, $rollout['variant3']); // 79.80
 });
 
 

--- a/tests/Functional/VariantTestCase.php
+++ b/tests/Functional/VariantTestCase.php
@@ -43,3 +43,13 @@ test('an identifier can have different variant on different experiment', functio
     $variantRetriever = generateVariantRetriever('my-other-ab-test');
     $this->assertEquals('variant', (string)$variantRetriever->getVariantForExperiment(new Experiment('my-other-ab-test'), $identifier));
 });
+
+test('differents variants with same name should throw exception', function () {
+    new VariantRetriever(new Experiment(DEFAULT_EXPERIMENT_NAME, ...[
+        new Variant('control'),
+        new Variant('variant1', 20),
+        new Variant('control', 20),
+        new Variant('variant1', 10),
+    ]));
+})->throws(LogicalException::class, 'Variant with same name "control" already added');
+


### PR DESCRIPTION
Add a test when adding variant to be sure they don't have same name